### PR TITLE
fix: rework shortcut clipboard copy (offscreen document) and drop broad host permissions

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -1,43 +1,51 @@
 import { INITIAL_OPTION_VALUES } from "../src/constant";
+import type { OptionsType } from "../src/options/Options";
 import { escapeBrackets, copyToClipboard } from "../src/util";
 
 export default defineBackground(() => {
-  chrome.commands.onCommand.addListener((command) => {
+  browser.commands.onCommand.addListener(async (command, tab) => {
     console.log("Command:", command);
 
-    const queryInfo = {
-      active: true,
-      currentWindow: true,
-    };
+    // The tab argument can be missing (e.g. on Firefox < 126), so fall
+    // back to querying the last focused window. Don't use
+    // `currentWindow: true` here: when a DevTools window has focus it
+    // matches that window, which has no tabs.
+    const activeTab =
+      tab ??
+      (await browser.tabs.query({ active: true, lastFocusedWindow: true }))[0];
+    if (!activeTab?.id) {
+      console.warn("No active tab found for command:", command);
+      return;
+    }
 
-    chrome.tabs.query(queryInfo, function (tabs) {
-      // All commands are like `copy_as_format_*` (*: 1 or 2 or 3)
-      const formatIndex = command.slice(-1);
-      console.log("format: ", formatIndex);
+    // All commands are like `copy_as_format_*` (*: 1 or 2 or 3)
+    const formatIndex = command.slice(-1);
+    console.log("format: ", formatIndex);
 
-      const key = `optionalFormat${formatIndex}`;
-      chrome.storage.local.get(INITIAL_OPTION_VALUES, function (options) {
-        const tab = tabs[0];
-        const title = tab.title || "";
-        const url = tab.url || "";
-        const tabId = tab.id || 0;
+    const key = `optionalFormat${formatIndex}` as keyof OptionsType;
+    const options = (await browser.storage.local.get(
+      INITIAL_OPTION_VALUES,
+    )) as OptionsType;
 
-        console.log(tab.url, tab.title);
-        console.log(options);
+    const title = activeTab.title || "";
+    const url = activeTab.url || "";
 
-        chrome.scripting.executeScript({
-          target: { tabId },
-          func: copyToClipboard,
-          args: [options[key], title, escapeBrackets(url)],
-        });
+    console.log(url, title);
+    console.log(options);
 
-        chrome.action.setBadgeText({ text: formatIndex });
-        setTimeout(() => {
-          chrome.action.setBadgeText({ text: "" });
-        }, 1000);
-
-        console.log("done!");
-      });
+    await browser.scripting.executeScript({
+      target: { tabId: activeTab.id },
+      func: copyToClipboard,
+      args: [options[key], title, escapeBrackets(url)],
     });
+
+    // MV2 (Firefox) uses browserAction instead of action
+    const action = browser.action ?? browser.browserAction;
+    action.setBadgeText({ text: formatIndex });
+    setTimeout(() => {
+      action.setBadgeText({ text: "" });
+    }, 1000);
+
+    console.log("done!");
   });
 });

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -1,19 +1,47 @@
 import { INITIAL_OPTION_VALUES } from "../src/constant";
+import type { CopyToClipboardMessage } from "../src/messages";
 import type { OptionsType } from "../src/options/Options";
-import { escapeBrackets, copyToClipboard } from "../src/util";
+import { buildTemplate, escapeBrackets } from "../src/util";
+
+const OFFSCREEN_URL = "/offscreen.html";
+
+// The service worker has no DOM and Chrome doesn't expose
+// navigator.clipboard to extension service workers, so the actual
+// clipboard write happens in an offscreen document.
+// https://developer.chrome.com/docs/extensions/reference/api/offscreen
+async function copyViaOffscreen(text: string) {
+  const contexts = await browser.runtime.getContexts({
+    contextTypes: ["OFFSCREEN_DOCUMENT"],
+    documentUrls: [browser.runtime.getURL(OFFSCREEN_URL)],
+  });
+  if (contexts.length === 0) {
+    await browser.offscreen.createDocument({
+      url: OFFSCREEN_URL,
+      reasons: ["CLIPBOARD"],
+      justification:
+        "Write the formatted tab title and URL to the clipboard when a keyboard shortcut is pressed.",
+    });
+  }
+
+  const message: CopyToClipboardMessage = {
+    target: "offscreen",
+    type: "copy-to-clipboard",
+    text,
+  };
+  await browser.runtime.sendMessage(message);
+}
 
 export default defineBackground(() => {
   browser.commands.onCommand.addListener(async (command, tab) => {
     console.log("Command:", command);
 
-    // The tab argument can be missing (e.g. on Firefox < 126), so fall
-    // back to querying the last focused window. Don't use
-    // `currentWindow: true` here: when a DevTools window has focus it
-    // matches that window, which has no tabs.
+    // Fall back to a query in case the tab argument is missing. Don't
+    // use `currentWindow: true` here: when a DevTools window has focus
+    // it matches that window, which has no tabs.
     const activeTab =
       tab ??
       (await browser.tabs.query({ active: true, lastFocusedWindow: true }))[0];
-    if (!activeTab?.id) {
+    if (!activeTab) {
       console.warn("No active tab found for command:", command);
       return;
     }
@@ -33,17 +61,13 @@ export default defineBackground(() => {
     console.log(url, title);
     console.log(options);
 
-    await browser.scripting.executeScript({
-      target: { tabId: activeTab.id },
-      func: copyToClipboard,
-      args: [options[key], title, escapeBrackets(url)],
-    });
+    await copyViaOffscreen(
+      buildTemplate(options[key], title, escapeBrackets(url)),
+    );
 
-    // MV2 (Firefox) uses browserAction instead of action
-    const action = browser.action ?? browser.browserAction;
-    action.setBadgeText({ text: formatIndex });
+    browser.action.setBadgeText({ text: formatIndex });
     setTimeout(() => {
-      action.setBadgeText({ text: "" });
+      browser.action.setBadgeText({ text: "" });
     }, 1000);
 
     console.log("done!");

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -39,8 +39,7 @@ export default defineBackground(() => {
     // use `currentWindow: true` here: when a DevTools window has focus
     // it matches that window, which has no tabs.
     const activeTab =
-      tab ??
-      (await browser.tabs.query({ active: true, lastFocusedWindow: true }))[0];
+      tab ?? (await browser.tabs.query({ active: true, lastFocusedWindow: true }))[0];
     if (!activeTab) {
       console.warn("No active tab found for command:", command);
       return;
@@ -51,9 +50,7 @@ export default defineBackground(() => {
     console.log("format: ", formatIndex);
 
     const key = `optionalFormat${formatIndex}` as keyof OptionsType;
-    const options = (await browser.storage.local.get(
-      INITIAL_OPTION_VALUES,
-    )) as OptionsType;
+    const options = (await browser.storage.local.get(INITIAL_OPTION_VALUES)) as OptionsType;
 
     const title = activeTab.title || "";
     const url = activeTab.url || "";
@@ -61,9 +58,7 @@ export default defineBackground(() => {
     console.log(url, title);
     console.log(options);
 
-    await copyViaOffscreen(
-      buildTemplate(options[key], title, escapeBrackets(url)),
-    );
+    await copyViaOffscreen(buildTemplate(options[key], title, escapeBrackets(url)));
 
     browser.action.setBadgeText({ text: formatIndex });
     setTimeout(() => {

--- a/entrypoints/offscreen/index.html
+++ b/entrypoints/offscreen/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Offscreen clipboard writer</title>
+  </head>
+  <body>
+    <textarea id="clipboard"></textarea>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/entrypoints/offscreen/main.ts
+++ b/entrypoints/offscreen/main.ts
@@ -1,0 +1,16 @@
+import type { CopyToClipboardMessage } from "../../src/messages";
+
+// Offscreen documents are never focused, so the async Clipboard API
+// (navigator.clipboard) is not usable here; execCommand("copy") works
+// without focus thanks to the clipboardWrite permission.
+// https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Interact_with_the_clipboard
+browser.runtime.onMessage.addListener((message: CopyToClipboardMessage) => {
+  if (message?.target !== "offscreen" || message?.type !== "copy-to-clipboard") {
+    return;
+  }
+
+  const textarea = document.querySelector<HTMLTextAreaElement>("#clipboard")!;
+  textarea.value = message.text;
+  textarea.select();
+  document.execCommand("copy");
+});

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,0 +1,5 @@
+export type CopyToClipboardMessage = {
+  target: "offscreen";
+  type: "copy-to-clipboard";
+  text: string;
+};

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -15,7 +15,6 @@ export default defineConfig({
       "128": "/icon128.png",
     },
     permissions: ["activeTab", "clipboardWrite", "scripting", "storage"],
-    host_permissions: ["https://*/*", "http://*/*"],
     commands: {
       _execute_action: {
         suggested_key: {

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
     icons: {
       "128": "/icon128.png",
     },
-    permissions: ["activeTab", "clipboardWrite", "scripting", "storage"],
+    permissions: ["activeTab", "clipboardWrite", "offscreen", "storage"],
     commands: {
       _execute_action: {
         suggested_key: {


### PR DESCRIPTION
Fixes #441
Fixes #361

## Background

Investigation revealed that shortcut-based copy (`Ctrl+Shift+1/2`) has been broken since v2.0.1, due to two independent bugs, and that the broad `host_permissions` added in #360 was a misdiagnosis that never fixed the original issue (#351) while triggering the scary "Read and change all your data on all websites" warning.

Detailed analysis with references: [issue #441 comment](https://github.com/zaki-yama/copy-title-and-url-as-markdown/issues/441#issuecomment-4904388414) / [issue #361 comment](https://github.com/zaki-yama/copy-title-and-url-as-markdown/issues/361#issuecomment-4904391270)

## Changes

### 1. Get the active tab from the `onCommand` listener argument (`53ce12b`)

`tabs.query({ active: true, currentWindow: true })` returns an empty array when a DevTools window (including the SW console) has focus, causing the reported `TypeError: Cannot read properties of undefined (reading 'title')`. The tab passed directly to the `commands.onCommand` listener is used instead, with a `lastFocusedWindow` query as fallback.

### 2. Remove `host_permissions` (`933ff12`)

The already-declared `activeTab` permission is granted on both toolbar clicks and [keyboard shortcuts from the commands API](https://developer.chrome.com/docs/extensions/develop/concepts/activeTab), and is sufficient for reading the active tab's title/URL. This removes the "all websites" install warning. Since this is a permission reduction, existing users are not re-prompted.

### 3. Copy via an offscreen document instead of page injection (`774ddd0`)

Even with fix 1, the copy failed: `chrome.scripting.executeScript({ func: copyToClipboard })` serializes only the function itself, and since #349 the function references an out-of-scope helper (`buildTemplate`), throwing `ReferenceError: T is not defined` in the page.

Instead of patching the injected function, the clipboard write now happens in an [offscreen document](https://developer.chrome.com/docs/extensions/reference/api/offscreen) (`reason: CLIPBOARD`), following [Chrome's official sample](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/functional-samples/cookbook.offscreen-clipboard-write). The template is applied in the background script, and the offscreen page copies the final text.

This eliminates page injection entirely, so:
- this class of serialization bug is structurally impossible
- shortcuts also work on pages that don't allow injection (`chrome://` pages, Chrome Web Store, etc.)
- the `scripting` permission is no longer needed

Final permission set: `activeTab`, `clipboardWrite`, `offscreen`, `storage` — none of which produce an install-time warning.

## Verification

Verified end-to-end on Chrome 149 with a locally loaded build (no host permissions):
- `Ctrl+Shift+1` on a regular page → clipboard contains the optional format result (`${title}\n${url}`)
- Toolbar popup → clipboard contains the main format result (`[${title}](${url})`)
- Service worker console shows no errors
- `pnpm test` (17 tests) and `pnpm lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)