### PR TITLE
fix: match release-please tag format to existing v* tags

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
   "packages": {
-    ".": {}
+    ".": {
+      "include-component-in-tag": false
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Manifest mode defaults to searching for release tags in the `<component>-v<version>` format (e.g. `copy-title-and-url-as-markdown-v2.1.0`)
- This repo's actual tags are plain `v<version>` (`v1.8.0` ... `v2.1.0`, no component prefix), so release-please couldn't locate the last release tag
- It fell back to scanning the full commit history from the beginning of the repo, picked up an old, already-released `BREAKING CHANGE` commit (`release manifest v3 (#346)`), and proposed an incorrect major bump to `3.0.0` in #464
- Setting `include-component-in-tag: false` makes it search for `v<version>` tags instead, matching this repo's actual history

Closes the tag-format issue surfaced by #464 (#464 will be closed as invalid once this merges)

## Test plan
- [ ] After merging, manually run the `release-please` workflow again and confirm it proposes a sane version bump (based only on commits since `v2.1.0`) instead of `3.0.0`