### PR TITLE
docs(site): add Google Analytics tracking

### DIFF
--- a/site/src/layouts/Layout.astro
+++ b/site/src/layouts/Layout.astro
@@ -13,6 +13,8 @@ const {
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, "");
 const repoUrl = "https://github.com/zaki-yama/copy-title-and-url-as-markdown";
+
+const GA_MEASUREMENT_ID = "G-GT7XLL9FH2";
 ---
 
 <html lang="en" class="bg-white text-ink">
@@ -28,6 +30,22 @@ const repoUrl = "https://github.com/zaki-yama/copy-title-and-url-as-markdown";
       rel="stylesheet"
     />
     <title>{title}</title>
+    {
+      import.meta.env.PROD && (
+        <>
+          <script is:inline async src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`} />
+          <script
+            is:inline
+            set:html={`
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
+              gtag('config', '${GA_MEASUREMENT_ID}');
+            `}
+          />
+        </>
+      )
+    }
   </head>
   <body class="font-sans text-base leading-relaxed">
     <header class="sticky top-0 z-10 border-b border-line bg-white/85 backdrop-blur-md">


### PR DESCRIPTION
## Summary
- Add GA4 (`G-GT7XLL9FH2`) tracking to the product site via gtag.js
- Script is only injected when `import.meta.env.PROD` is true, so local `pnpm dev` traffic isn't recorded

## Reference: Partytown alternative
Astro also offers an [official Partytown integration](https://docs.astro.build/en/guides/integrations-guide/partytown/) for loading third-party scripts like gtag.js off the main thread (in a web worker), which can help performance on sites with several heavy third-party scripts.

This site only loads one third-party script (GA), so a plain `<script>` tag was used for simplicity. Partytown is worth revisiting if more third-party scripts (ads, etc.) are added later and main-thread performance becomes a concern.

## Test plan
- [x] `pnpm build` succeeds and `dist/index.html` contains the gtag.js snippet
- [x] `pnpm dev` (local server) does NOT include the gtag.js snippet, confirmed via curl