### PR TITLE
refactor: replace chrome.* APIs with browser from wxt/browser

### DIFF
--- a/components/options/Options.tsx
+++ b/components/options/Options.tsx
@@ -20,30 +20,28 @@ export const Options: React.FC = () => {
   const [showToast, setShowToast] = useState(false);
 
   useEffect(() => {
-    chrome.storage.local.get(INITIAL_OPTION_VALUES, (savedOptions) => {
+    const loadOptions = async () => {
+      const savedOptions = (await browser.storage.local.get(INITIAL_OPTION_VALUES)) as OptionsType;
       setOptions({
         format: escapeTabsAndNewLines(savedOptions.format),
         optionalFormat1: escapeTabsAndNewLines(savedOptions.optionalFormat1),
         optionalFormat2: escapeTabsAndNewLines(savedOptions.optionalFormat2),
       });
-    });
+    };
+    loadOptions();
   }, []);
 
   const handleChange = (key: keyof OptionsType, value: string) => {
     setOptions({ ...options, [key]: value });
   };
 
-  const onSave = () => {
-    chrome.storage.local.set(
-      {
-        format: unescapeTabsAndNewLines(options.format),
-        optionalFormat1: unescapeTabsAndNewLines(options.optionalFormat1),
-        optionalFormat2: unescapeTabsAndNewLines(options.optionalFormat2),
-      },
-      () => {
-        setShowToast(true);
-      },
-    );
+  const onSave = async () => {
+    await browser.storage.local.set({
+      format: unescapeTabsAndNewLines(options.format),
+      optionalFormat1: unescapeTabsAndNewLines(options.optionalFormat1),
+      optionalFormat2: unescapeTabsAndNewLines(options.optionalFormat2),
+    });
+    setShowToast(true);
   };
 
   return (

--- a/entrypoints/popup/main.tsx
+++ b/entrypoints/popup/main.tsx
@@ -10,17 +10,21 @@ const queryInfo = {
   currentWindow: true,
 };
 
-chrome.tabs.query(queryInfo, function (tabs) {
-  chrome.storage.local.get({ format: DEFAULT_FORMAT }, function (options) {
-    const tab = tabs[0];
-    const title = tab.title || "";
-    const url = tab.url || "";
-    copyToClipboard(options.format, title, escapeBrackets(url));
+async function main() {
+  const tabs = await browser.tabs.query(queryInfo);
+  const options = (await browser.storage.local.get({ format: DEFAULT_FORMAT })) as {
+    format: string;
+  };
+  const tab = tabs[0];
+  const title = tab.title || "";
+  const url = tab.url || "";
+  copyToClipboard(options.format, title, escapeBrackets(url));
 
-    ReactDOM.createRoot(document.getElementById("root")!).render(
-      <React.StrictMode>
-        <Popup title={title} url={escapeBrackets(url)} />
-      </React.StrictMode>,
-    );
-  });
-});
+  ReactDOM.createRoot(document.getElementById("root")!).render(
+    <React.StrictMode>
+      <Popup title={title} url={escapeBrackets(url)} />
+    </React.StrictMode>,
+  );
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
   },
   "devDependencies": {
     "@ladle/react": "^5.1.1",
-    "@types/chrome": "0.0.332",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@wxt-dev/module-react": "^1.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,9 +42,6 @@ importers:
       '@ladle/react':
         specifier: ^5.1.1
         version: 5.1.1(@types/node@26.1.1)(@types/react@19.2.17)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(terser@5.46.0)(typescript@5.9.3)
-      '@types/chrome':
-        specifier: 0.0.332
-        version: 0.0.332
       '@types/react':
         specifier: 19.2.17
         version: 19.2.17
@@ -1384,9 +1381,6 @@ packages:
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
-
-  '@types/chrome@0.0.332':
-    resolution: {integrity: sha512-Fl4luF9q/iroXMKbL1LQyr/nCKhKwkwkZQ9qeeePFECW/8SP/Lrx2kJ26wnpTpr0iAznkENoO8g924CP4mfNxw==}
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
@@ -4991,11 +4985,6 @@ snapshots:
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
-
-  '@types/chrome@0.0.332':
-    dependencies:
-      '@types/filesystem': 0.0.36
-      '@types/har-format': 1.2.16
 
   '@types/debug@4.1.12':
     dependencies:


### PR DESCRIPTION
## Overview

Replaces the remaining callback-style `chrome.*` API usages with WXT's auto-imported, promise-based `browser` global (`wxt/browser`), for cross-browser compatibility. Closes #388.

`entrypoints/background.ts` and `entrypoints/offscreen/main.ts` had already been migrated, so the actual targets were:

- `entrypoints/popup/main.tsx` — `chrome.tabs.query` / `chrome.storage.local.get` (callback style) → `await browser.*`
- `components/options/Options.tsx` — `chrome.storage.local.get/set` (callback style) → `await browser.*`

Storage results are cast with `as OptionsType` / `as { format: string }`, matching the existing pattern in `background.ts` (`@wxt-dev/browser` types return `Record<string, unknown>`).

Since nothing references the `chrome` global anymore, `@types/chrome` is removed from devDependencies. This also unblocks the TypeScript 7 upgrade (#482), where the new default `types: []` stops auto-loading `@types/*` packages.

## Verification

- `pnpm typecheck` / `pnpm lint` / `pnpm fmt:check` ✅
- `pnpm test` — 17 tests passed ✅
- `pnpm build` and `pnpm build:firefox` ✅ — confirmed the popup/options chunks import the shared `browser` shim (`globalThis.browser?.runtime?.id ? globalThis.browser : globalThis.chrome`) in the build output

🤖 Generated with [Claude Code](https://claude.com/claude-code)